### PR TITLE
fix: try pinning dotnet-sdk version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,9 +24,9 @@
     },
     {
       "matchPackageNames": [
-        "dotnet-sdk"
+        "sdk"
       ],
-      "matchCurrentVersion": "6.0.300"
+      "matchCurrentVersion": "6.0.405"
     }
   ]
 }


### PR DESCRIPTION
let's see if this makes renovate bot stop trying to update dotnet-sdk to v7/8