### PR TITLE
fix: automatically make new generated projects be version 1.0.0 by default

### DIFF
--- a/Chickensoft.GodotPackage/Chickensoft.GodotPackage.csproj
+++ b/Chickensoft.GodotPackage/Chickensoft.GodotPackage.csproj
@@ -12,7 +12,7 @@
     <DebugType>portable</DebugType>
 
     <Title>Chickensoft.GodotPackage</Title>
-    <Version>1.0.0-rc.4.0.0.5</Version>
+    <Version>1.0.0</Version>
     <Description />
     <Copyright>© 2023 YourName</Copyright>
     <Authors>YourName</Authors>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This template allows you to easily create a nuget package for use in Godot 4 C# 
 
 ```sh
 # Install this template
-dotnet new --install Chickensoft.GodotPackage::1.0.0-rc.4.0.0.5 # or latest
+dotnet new --install Chickensoft.GodotPackage
 
 # Generate a new project based on this template
 dotnet new chickenpackage --name "MyPackageName" --param:author "My Name"


### PR DESCRIPTION
- fix: automatically make new generated projects be version 1.0.0 by default