### PR TITLE
Prevent renovate from updating project to preview .NET SDKs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,12 @@
     },
     {
       "matchPackagePrefixes": [
+        "dotnet-sdk"
+      ],
+      "allowedVersions": "!/preview/"
+    },
+    {
+      "matchPackagePrefixes": [
         "GodotSharp",
         "Godot.NET.Sdk"
       ],


### PR DESCRIPTION
Currently, renovate is updating this project to use preview builds of the .NET SDK, which in turn requires users to install the latest preview .NET, or change the project settings manually when they use this tool to create a new project (or face a somewhat opaque build error if using the documented CLI build process for the test project).

I'm not super well-versed in renovate, but I believe this change disallows .NET preview builds in renovate's updates. I've checked this by setting the dotnet-sdk version to 8.0.204 (latest stable as of writing) in a local clone of the repo and doing local dry runs of renovate with `LOG_LEVEL=debug npx renovate --platform=local --repository-cache=reset`.

Without this change, a local dry run of renovate prompts an update to 9.0 preview:
```
"depType": "dotnet-sdk",
"depName": "dotnet-sdk",
"currentValue": "8.0.204",
"datasource": "dotnet-version",
"updates": [
 {
   "bucket": "major",
   "newVersion": "9.0.100-preview.3.24204.13",
   "newValue": "9.0.100-preview.3.24204.13",
   "releaseTimestamp": "2024-04-11T00:00:00.000Z",
   "newMajor": 9,
   "newMinor": 0,
   "updateType": "major",
   "branchName": "renovate/major-all-deps"
 }
],
"packageName": "dotnet-sdk",
"versioning": "loose",
"warnings": [],
"sourceUrl": "https://github.com/dotnet/sdk",
"registryUrl": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
"currentVersion": "8.0.204",
"isSingleVersion": true,
"fixedVersion": "8.0.204"
```

With this change, a local dry run does *not* prompt an update to 9.0 preview:
```
"depType": "dotnet-sdk",
"depName": "dotnet-sdk",
"currentValue": "8.0.204",
"datasource": "dotnet-version",
"updates": [],
```

To verify that this change still suggests updates to non-preview versions, I set dotnet-sdk's version to 8.0.104 and the local dry run prompts to update to 8.0.204:
```
"depType": "dotnet-sdk",
"depName": "dotnet-sdk",
"currentValue": "8.0.104",
"datasource": "dotnet-version",
"updates": [
 {
   "bucket": "non-major",
   "newVersion": "8.0.204",
   "newValue": "8.0.204",
   "releaseTimestamp": "2024-04-09T00:00:00.000Z",
   "newMajor": 8,
   "newMinor": 0,
   "updateType": "patch",
   "branchName": "renovate/all-deps"
 }
],
```