### PR TITLE
Fix build errors for non-Chickensoft packages

### DIFF
--- a/Chickensoft.GodotPackage.Tests/test/Tests.cs
+++ b/Chickensoft.GodotPackage.Tests/test/Tests.cs
@@ -2,7 +2,7 @@ namespace Chickensoft.GodotPackage.Tests;
 
 using System.Reflection;
 using Godot;
-using GoDotTest;
+using Chickensoft.GoDotTest;
 
 public partial class Tests : Node2D {
   public override void _Ready()


### PR DESCRIPTION
Fixes #96 by fully qualifying `Chickensoft.GoDotTest` in a using statement, so that packages created with this tool that are not in the `Chickensoft` namespace will build without errors.