### PR TITLE
Roll back .NET to stable version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.3.24204.13",
+    "version": "8.0.204",
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
Follows on from #95 to roll back the .NET SDK to latest stable instead of a preview version.