### PR TITLE
chore: fix run-tests action on forks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,6 @@ jobs:
       - name: 🧾 Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_BASIC }}
           lfs: true
           submodules: 'recursive'
 


### PR DESCRIPTION
The GitHub token in the checkout step for the Tests action isn't required (see, e.g., GoDotLog, other Chickensoft repos). Including it causes the Tests action to fail at that step in forks that don't have a GitHub token configured:

![Screenshot 2024-09-29 172416](https://github.com/user-attachments/assets/3f84b4a6-38de-420c-a568-ddc5f62f571d)

(See also failing Tests action in #121)

Removing the token allows forks to run the Tests action.