### PR TITLE
chore: roll .NET back to v8, use common renovate

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.203",
+    "version": "8.0.408",
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,35 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":semanticCommits"
-  ],
-  "prHourlyLimit": 2,
-  "packageRules": [
-    {
-      "groupName": "all dependencies",
-      "groupSlug": "all-deps",
-      "automerge": true,
-      "matchPackageNames": [
-        "*"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "dotnet-sdk{/,}**"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "GodotSharp{/,}**",
-        "Godot.NET.Sdk{/,}**"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "Chickensoft{/,}**"
-      ],
-      "allowedVersions": "/^(\\d+\\.\\d+\\.\\d+)(-godot(\\d+\\.)+\\d+(-.*)?)?$/"
-    }
-  ]
+  "extends": ["github>chickensoft-games/renovate:godot"]
 }


### PR DESCRIPTION
Rolled global.json's .NET back to v8. Changed to the common Chickensoft renovate configuration, to prevent renovate from updating to v9.