### PR TITLE
fix: don't clear nuget sources

### DIFF
--- a/Chickensoft.GodotPackage.Tests/nuget.config
+++ b/Chickensoft.GodotPackage.Tests/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <!-- Default nuget feed -->
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
Removed nuget.config file that was only clearing nuget sources and re-adding the default source. Previously, any custom sources the user had set up would be unavailable in the Tests directory.

See also chickensoft-games/GodotGame#169.